### PR TITLE
Ready for Release v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * [compatibility, CSS] Load MW core CSS that was dropped in MW 1.35
 * [code] Drop Travis-CI and move to CircleCI
 * [code] Update php-parallel-lint to a supported branch with PHP 8.0
+* [deprecated, code] Updated deprecated code
 
 ## Version 2.2.2
 * [bug, enhancement] Fix to allow multiple methods of login such as MW-OAuth2Client - Issue #99

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-# Version 2.3.0
-* [compatibility, CSS] Load MW core CSS that was dropped in MW 1.35
-* [code] Drop Travis-CI and move to CircleCI
-* [code] Update php-parallel-lint to a supported branch with PHP 8.0
-* [deprecated, code] Updated deprecated code
-
 ## Version 2.2.2
 * [bug, enhancement] Fix to allow multiple methods of login such as MW-OAuth2Client - Issue #99
 * [bug, enhancement] Left-menu search (on mobile widths only) doesn't auto-complete #98

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 2.3.0-dev
+* [compatibility, CSS] Load MW core CSS that was dropped in MW 1.35
+* [code] Drop Travis-CI and move to CircleCI
+* [code] Update php-parallel-lint to a supported branch with PHP 8.0
+
 ## Version 2.2.2-dev
 * [bug, enhancement] Fix to allow multiple methods of login such as MW-OAuth2Client - Issue #99
 * [bug, enhancement] Left-menu search (on mobile widths only) doesn't auto-complete #98

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
-# Version 2.3.0-dev
+# Version 2.3.0
 * [compatibility, CSS] Load MW core CSS that was dropped in MW 1.35
 * [code] Drop Travis-CI and move to CircleCI
 * [code] Update php-parallel-lint to a supported branch with PHP 8.0
 
-## Version 2.2.2-dev
+## Version 2.2.2
 * [bug, enhancement] Fix to allow multiple methods of login such as MW-OAuth2Client - Issue #99
 * [bug, enhancement] Left-menu search (on mobile widths only) doesn't auto-complete #98
 

--- a/Pivot.skin.php
+++ b/Pivot.skin.php
@@ -11,9 +11,7 @@
 class SkinPivot extends SkinTemplate {
 	public $skinname = 'pivot', $stylename = 'pivot', $template = 'pivotTemplate', $useHeadElement = true;
 	
-	public function setupSkinUserCss(OutputPage $out) {
-		parent::setupSkinUserCss($out);
-    	global $wgLocalStylePath;
+	public function getDefaultModules() {
 		global $wgPivotFeatures;
 		$wgPivotFeaturesDefaults = array(
 			'showActionsForAnon' => true,
@@ -37,11 +35,11 @@ class SkinPivot extends SkinTemplate {
 		}
 		
 		if ( $wgPivotFeatures['preloadFontAwesome'] ) {
-			$out->addHeadItem('font', '<link rel="preload" href="'.$wgLocalStylePath.'/pivot/assets/fonts/fontawesome-webfont.woff2?v=4.7.0" as="font" type="font/woff2" crossorigin="anonymous" />');
+			$this->getOutput()->addHeadItem('font', '<link rel="preload" href="'.$wgLocalStylePath.'/pivot/assets/fonts/fontawesome-webfont.woff2?v=4.7.0" as="font" type="font/woff2" crossorigin="anonymous" />');
 		}
 		
-		$out->addModuleStyles('skins.pivot.styles');
-
+		$this->getOutput()->addModuleStyles('skins.pivot.styles');
+    	return parent::getDefaultModules();
 	}
 	
 	public function initPage(OutputPage $out) {
@@ -297,7 +295,7 @@ class pivotTemplate extends BaseTemplate {
 	function renderSidebar() { 
 		$sidebar = $this->getSidebar();
 		foreach ($sidebar as $boxName => $box) { 
-			echo '<li><label class="sidebar" id="'.Sanitizer::escapeId( $box['id'] ).'"';echo Linker::tooltip( $box['id'] ).'>'.htmlspecialchars( $box['header'] ).'</label></li>';
+			echo '<li><label class="sidebar" id="'.Sanitizer::escapeIdForAttribute( $box['id'] ).'"';echo Linker::tooltip( $box['id'] ).'>'.htmlspecialchars( $box['header'] ).'</label></li>';
 					if ( is_array( $box['content'] ) ) {
 							foreach ($box['content'] as $key => $item) { echo $this->makeListItem($key, $item); }
 								} 

--- a/assets/stylesheets/legacy.css
+++ b/assets/stylesheets/legacy.css
@@ -1,0 +1,756 @@
+@media screen {
+	/**
+	 * CSS in this file is used by *all* skins (that have any CSS at all). Be
+	 * careful what you put in here, since what looks good in one skin may not in
+	 * another, but don't ignore the poor pre-Monobook users either.
+	 *
+	 * NOTE: The images which are referenced in this file are no longer in use in
+	 * essential interface components. They should NOT be embedded, because that
+	 * optimizes for the uncommon case at the cost of bloating the size of render-
+	 * blocking CSS common to all pages.
+	 */
+	
+	/* GENERAL CLASSES FOR DIRECTIONALITY SUPPORT */
+	
+	/**
+	 * These classes should be used for text depending on the content direction.
+	 * Content stuff like editsection, ul/ol and TOC depend on this.
+	 */
+	.mw-content-ltr {
+		/* @noflip */
+		direction: ltr;
+	}
+	
+	.mw-content-rtl {
+		/* @noflip */
+		direction: rtl;
+	}
+	
+	/* Most input fields should be in site direction */
+	.sitedir-ltr textarea,
+	.sitedir-ltr input {
+		/* @noflip */
+		direction: ltr;
+	}
+	
+	.sitedir-rtl textarea,
+	.sitedir-rtl input {
+		/* @noflip */
+		direction: rtl;
+	}
+	
+	.mw-userlink {
+		unicode-bidi: embed;
+	}
+	
+	/* User-Agent styles for new HTML5 elements */
+	mark {
+		background-color: #ff0;
+		color: #000;
+	}
+	
+	/* Helper for wbr element on IE 8+; in HTML5, but not supported by default as of IE 11. */
+	/* Note canonical HTML5 styles recommend "content: \u200B", but this doesn't work as of IE 11. */
+	wbr {
+		display: inline-block;
+	}
+	
+	/* Input types that should follow user direction, like buttons */
+	/* TODO: What about buttons in wikipage content ? */
+	input[ type='submit' ],
+	input[ type='button' ],
+	input[ type='reset' ],
+	input[ type='file' ] {
+		direction: ltr;
+	}
+	
+	/* Override default values */
+	textarea[ dir='ltr' ],
+	input[ dir='ltr' ] {
+		/* @noflip */
+		direction: ltr;
+	}
+	
+	textarea[ dir='rtl' ],
+	input[ dir='rtl' ] {
+		/* @noflip */
+		direction: rtl;
+	}
+	
+	/* Default style for semantic tags */
+	abbr[ title ],
+	.explain[ title ] {
+		border-bottom: 1px dotted;
+		cursor: help;
+	}
+	
+	@supports ( text-decoration: underline dotted ) {
+		abbr[ title ],
+		.explain[ title ] {
+			border-bottom: 0;
+			text-decoration: underline dotted;
+		}
+	}
+	
+	/* Comment portions of RC entries */
+	span.comment {
+		font-style: italic;
+		unicode-bidi: -moz-isolate;
+		unicode-bidi: isolate;
+	}
+	
+	/* Stop floats from intruding into edit area in previews */
+	#editform,
+	#toolbar,
+	#wpTextbox1 {
+		clear: both;
+	}
+	
+	/* Prevent editing textarea from jumping when toolbar is loaded */
+	#toolbar {
+		height: 22px;
+	}
+	
+	/* Underline preference */
+	
+	.mw-underline-always a {
+		text-decoration: underline;
+	}
+	
+	.mw-underline-never a {
+		text-decoration: none;
+	}
+	
+	/**
+	 * rev_deleted stuff
+	 */
+	li span.deleted,
+	span.history-deleted {
+		text-decoration: line-through;
+		color: #72777d;
+		font-style: italic;
+	}
+	
+	/**
+	 * Patrol stuff
+	 */
+	.not-patrolled {
+		background-color: #ffa;
+	}
+	
+	.unpatrolled {
+		font-weight: bold;
+		color: #d33;
+	}
+	
+	div.patrollink {
+		font-size: 75%;
+		text-align: right;
+	}
+	
+	/**
+	 * Forms
+	 */
+	td.mw-label {
+		text-align: right;
+		vertical-align: middle;
+	}
+	
+	td.mw-input {
+		text-align: left;
+	}
+	
+	td.mw-submit {
+		text-align: left;
+		white-space: nowrap;
+	}
+	
+	.mw-input-with-label {
+		white-space: nowrap;
+		display: inline-block;
+	}
+	
+	/**
+	 * Image captions.
+	 *
+	 * This is only meant to provide the most basic of styles, visual settings shouldn't be added here.
+	 */
+	
+	/* @noflip */
+	.mw-content-ltr .thumbcaption {
+		text-align: left;
+	}
+	
+	/* @noflip */
+	.mw-content-ltr .magnify {
+		float: right;
+	}
+	
+	/* @noflip */
+	.mw-content-rtl .thumbcaption {
+		text-align: right;
+	}
+	
+	/* @noflip */
+	.mw-content-rtl .magnify {
+		float: left;
+	}
+	
+	/**
+	 * Categories
+	 */
+	#catlinks {
+		/**
+		 * Overrides text justification (user preference)
+		 * See T33990
+		 */
+		text-align: left;
+	}
+	
+	.catlinks ul {
+		display: inline;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+		list-style-type: none;
+		list-style-image: none;
+		vertical-align: middle !ie;
+	}
+	
+	.catlinks li {
+		display: inline-block;
+		line-height: 1.25em;
+		border-left: 1px solid #a2a9b1;
+		margin: 0.125em 0;
+		padding: 0 0.5em;
+		zoom: 1;
+		display: inline !ie; /* stylelint-disable-line declaration-block-no-duplicate-properties */
+	}
+	
+	.catlinks li:first-child {
+		padding-left: 0.25em;
+		border-left: 0;
+	}
+	
+	/* (T7346) make category redirects italic */
+	.catlinks li a.mw-redirect {
+		font-style: italic;
+	}
+	
+	/**
+	 * Hidden categories
+	 */
+	.mw-hidden-cats-hidden {
+		display: none;
+	}
+	
+	.catlinks-allhidden {
+		display: none;
+	}
+	
+	/**
+	 * Convenience links to edit delete and protect reasons
+	 */
+	p.mw-protect-editreasons,
+	p.mw-filedelete-editreasons,
+	p.mw-delete-editreasons {
+		font-size: 90%;
+		text-align: right;
+	}
+	
+	/* The auto-generated edit comments */
+	.autocomment {
+		color: #72777d;
+	}
+	
+	/** Generic minor/bot/newpage styling (recent changes) */
+	.newpage,
+	.minoredit,
+	.botedit {
+		font-weight: bold;
+	}
+	
+	/**
+	 * Recreating deleted page warning
+	 * Reupload file warning
+	 * Page protection warning
+	 * incl. log entries for these warnings
+	 */
+	div.mw-warning-with-logexcerpt {
+		padding: 3px;
+		margin-bottom: 3px;
+		border: 2px solid #2a4b8d;
+		clear: both;
+	}
+	
+	div.mw-warning-with-logexcerpt ul li {
+		font-size: 90%;
+	}
+	
+	/* (show/hide) revision deletion links */
+	span.mw-revdelundel-link,
+	strong.mw-revdelundel-link {
+		font-size: 90%;
+	}
+	
+	span.mw-revdelundel-hidden,
+	input.mw-revdelundel-hidden {
+		visibility: hidden;
+	}
+	
+	td.mw-revdel-checkbox,
+	th.mw-revdel-checkbox {
+		padding-right: 10px;
+		text-align: center;
+	}
+	
+	/* red links; see T38276 */
+	a.new {
+		color: #ba0000;
+	}
+	
+	/* Plainlinks - this can be used to switch
+	 * off special external link styling */
+	.plainlinks a.external {
+		background: none !important; /* stylelint-disable-line declaration-no-important */
+		padding: 0 !important; /* stylelint-disable-line declaration-no-important */
+	}
+	
+	/* External URLs should always be treated as LTR (T6330) */
+	/* @noflip */ .rtl a.external.free,
+	.rtl a.external.autonumber {
+		direction: ltr;
+		unicode-bidi: embed;
+	}
+	
+	/**
+	 * wikitable class for skinning normal tables
+	 * keep in sync with commonPrint.css
+	 */
+	table.wikitable {
+		background-color: #f8f9fa;
+		color: #222;
+		margin: 1em 0;
+		border: 1px solid #a2a9b1;
+		border-collapse: collapse;
+	}
+	
+	table.wikitable > tr > th,
+	table.wikitable > tr > td,
+	table.wikitable > * > tr > th,
+	table.wikitable > * > tr > td {
+		border: 1px solid #a2a9b1;
+		padding: 0.2em 0.4em;
+	}
+	
+	table.wikitable > tr > th,
+	table.wikitable > * > tr > th {
+		background-color: #eaecf0;
+		text-align: center;
+	}
+	
+	table.wikitable > caption {
+		font-weight: bold;
+	}
+	
+	/* success and error messages */
+	.error,
+	.warning,
+	.success {
+		font-size: larger;
+	}
+	
+	.error {
+		color: #d33;
+	}
+	
+	.warning {
+		color: #705000;
+	}
+	
+	.success {
+		color: #009000;
+	}
+	
+	.errorbox,
+	.warningbox,
+	.successbox {
+		border: 1px solid;
+		padding: 0.5em 1em;
+		margin-bottom: 1em;
+		display: inline-block;
+		zoom: 1;
+		*display: inline; /* stylelint-disable-line declaration-block-no-duplicate-properties */
+	}
+	
+	.errorbox h2,
+	.warningbox h2,
+	.successbox h2 {
+		font-size: 1em;
+		color: inherit;
+		font-weight: bold;
+		display: inline;
+		margin: 0 0.5em 0 0;
+		border: 0;
+	}
+	
+	.errorbox {
+		color: #d33;
+		border-color: #fac5c5;
+		background-color: #fae3e3;
+	}
+	
+	.warningbox {
+		color: #705000;
+		border-color: #fde29b;
+		background-color: #fdf1d1;
+	}
+	
+	.successbox {
+		color: #008000;
+		border-color: #b7fdb5;
+		background-color: #e1fddf;
+	}
+	
+	/* general info/warning box for SP */
+	.mw-infobox {
+		border: 2px solid #ff7f00;
+		margin: 0.5em;
+		clear: left;
+		overflow: hidden;
+	}
+	
+	.mw-infobox-left {
+		margin: 7px;
+		float: left;
+		width: 35px;
+	}
+	
+	.mw-infobox-right {
+		margin: 0.5em 0.5em 0.5em 49px;
+	}
+	
+	/* Note on preview page */
+	.previewnote {
+		color: #d33;
+		margin-bottom: 1em;
+	}
+	
+	.previewnote p {
+		text-indent: 3em;
+		margin: 0.8em 0;
+	}
+	
+	.visualClear {
+		clear: both;
+	}
+	
+	/**
+	 * Data table style
+	 *
+	 * Transparent table with suddle borders
+	 * and blue row-highlighting.
+	 */
+	.mw-datatable {
+		border-collapse: collapse;
+	}
+	
+	.mw-datatable,
+	.mw-datatable td,
+	.mw-datatable th {
+		border: 1px solid #a2a9b1;
+		padding: 0 0.15em 0 0.15em;
+	}
+	
+	.mw-datatable th {
+		background-color: #ddf;
+	}
+	
+	.mw-datatable td {
+		background-color: #fff;
+	}
+	
+	.mw-datatable tr:hover td {
+		background-color: #eaf3ff;
+	}
+	
+	/* Correct directionality when page dir is different from site/user dir */
+	.mw-content-ltr ul,
+	.mw-content-rtl .mw-content-ltr ul {
+		/* @noflip */
+		margin: 0.3em 0 0 1.6em;
+		padding: 0;
+	}
+	
+	.mw-content-rtl ul,
+	.mw-content-ltr .mw-content-rtl ul {
+		/* @noflip */
+		margin: 0.3em 1.6em 0 0;
+		padding: 0;
+	}
+	
+	.mw-content-ltr ol,
+	.mw-content-rtl .mw-content-ltr ol {
+		/* @noflip */
+		margin: 0.3em 0 0 3.2em;
+		padding: 0;
+	}
+	
+	.mw-content-rtl ol,
+	.mw-content-ltr .mw-content-rtl ol {
+		/* @noflip */
+		margin: 0.3em 3.2em 0 0;
+		padding: 0;
+	}
+	
+	/* @noflip */
+	.mw-content-ltr dd,
+	.mw-content-rtl .mw-content-ltr dd {
+		margin-left: 1.6em;
+		margin-right: 0;
+	}
+	
+	/* @noflip */
+	.mw-content-rtl dd,
+	.mw-content-ltr .mw-content-rtl dd {
+		margin-right: 1.6em;
+		margin-left: 0;
+	}
+	
+	.mw-ajax-loader {
+		background-image: url(/w/resources/src/mediawiki.legacy/images/ajax-loader.gif?57f34);
+		background-position: center center;
+		background-repeat: no-repeat;
+		padding: 16px;
+		position: relative;
+		top: -16px;
+	}
+	
+	.mw-small-spinner {
+		padding: 10px !important; /* stylelint-disable-line declaration-no-important */
+		margin-right: 0.6em;
+		background-image: url(/w/resources/src/mediawiki.legacy/images/spinner.gif?ca65b);
+		background-position: center center;
+		background-repeat: no-repeat;
+	}
+	
+	/* Language specific height correction for titles. Ref T31405 and T32809 */
+	/* Languages like hi or ml require slightly more vertical space to show diacritics properly */
+	h1:lang( anp ),
+	h1:lang( as ),
+	h1:lang( bh ), /* Macrolanguage, used on bh.wikipedia.org, should be removed one day */
+	h1:lang( bho ),
+	h1:lang( bn ),
+	h1:lang( gu ),
+	h1:lang( hi ),
+	h1:lang( kn ),
+	h1:lang( ks ),
+	h1:lang( ml ),
+	h1:lang( mr ),
+	h1:lang( my ),
+	h1:lang( mai ),
+	h1:lang( ne ),
+	h1:lang( new ),
+	h1:lang( or ),
+	h1:lang( pa ),
+	h1:lang( pi ),
+	h1:lang( sa ),
+	h1:lang( ta ),
+	h1:lang( te ) {
+		line-height: 1.6em !important; /* stylelint-disable-line declaration-no-important */
+	}
+	
+	/* stylelint-disable selector-list-comma-newline-after */
+	h2:lang( anp ), h3:lang( anp ), h4:lang( anp ), h5:lang( anp ), h6:lang( anp ),
+	h2:lang( as ), h3:lang( as ), h4:lang( as ), h5:lang( as ), h6:lang( as ),
+	h2:lang( bho ), h3:lang( bho ), h4:lang( bho ), h5:lang( bho ), h6:lang( bho ),
+	h2:lang( bh ), h3:lang( bh ), h4:lang( bh ), h5:lang( bh ), h6:lang( bh ),
+	h2:lang( bn ), h3:lang( bn ), h4:lang( bn ), h5:lang( bn ), h6:lang( bn ),
+	h2:lang( gu ), h3:lang( gu ), h4:lang( gu ), h5:lang( gu ), h6:lang( gu ),
+	h2:lang( hi ), h3:lang( hi ), h4:lang( hi ), h5:lang( hi ), h6:lang( hi ),
+	h2:lang( kn ), h3:lang( kn ), h4:lang( kn ), h5:lang( kn ), h6:lang( kn ),
+	h2:lang( ks ), h3:lang( ks ), h4:lang( ks ), h5:lang( ks ), h6:lang( ks ),
+	h2:lang( ml ), h3:lang( ml ), h4:lang( ml ), h5:lang( ml ), h6:lang( ml ),
+	h2:lang( mr ), h3:lang( mr ), h4:lang( mr ), h5:lang( mr ), h6:lang( mr ),
+	h2:lang( my ), h3:lang( my ), h4:lang( my ), h5:lang( my ), h6:lang( my ),
+	h2:lang( mai ), h3:lang( mai ), h4:lang( mai ), h5:lang( mai ), h6:lang( mai ),
+	h2:lang( ne ), h3:lang( ne ), h4:lang( ne ), h5:lang( ne ), h6:lang( ne ),
+	h2:lang( new ), h3:lang( new ), h4:lang( new ), h5:lang( new ), h6:lang( new ),
+	h2:lang( or ), h3:lang( or ), h4:lang( or ), h5:lang( or ), h6:lang( or ),
+	h2:lang( pa ), h3:lang( pa ), h4:lang( pa ), h5:lang( pa ), h6:lang( pa ),
+	h2:lang( pi ), h3:lang( pi ), h4:lang( pi ), h5:lang( pi ), h6:lang( pi ),
+	h2:lang( sa ), h3:lang( sa ), h4:lang( sa ), h5:lang( sa ), h6:lang( sa ),
+	h2:lang( ta ), h3:lang( ta ), h4:lang( ta ), h5:lang( ta ), h6:lang( ta ),
+	h2:lang( te ), h3:lang( te ), h4:lang( te ), h5:lang( te ), h6:lang( te ) {
+		line-height: 1.2em;
+	}
+	/* stylelint-enable selector-list-comma-newline-after */
+	
+	/* Localised ordered list numbering for some languages */
+	ol:lang( azb ) li,
+	ol:lang( bcc ) li,
+	ol:lang( bgn ) li,
+	ol:lang( bqi ) li,
+	ol:lang( fa ) li,
+	ol:lang( glk ) li,
+	ol:lang( kk-arab ) li,
+	ol:lang( lrc ) li,
+	ol:lang( luz ) li,
+	ol:lang( mzn ) li {
+		list-style-type: -moz-persian;
+		list-style-type: persian;
+	}
+	
+	ol:lang( ckb ) li,
+	ol:lang( sdh ) li {
+		list-style-type: -moz-arabic-indic;
+		list-style-type: arabic-indic;
+	}
+	
+	ol:lang( hi ) li,
+	ol:lang( mai ) li,
+	ol:lang( mr ) li,
+	ol:lang( ne ) li {
+		list-style-type: -moz-devanagari;
+		list-style-type: devanagari;
+	}
+	
+	ol:lang( as ) li,
+	ol:lang( bn ) li {
+		list-style-type: -moz-bengali;
+		list-style-type: bengali;
+	}
+	
+	ol:lang( or ) li {
+		list-style-type: -moz-oriya;
+		list-style-type: oriya;
+	}
+	
+	.toc ul {
+		margin: 0.3em 0;
+	}
+	
+	/* Correct directionality when page dir is different from site/user dir */
+	/* @noflip */ .mw-content-ltr .toc ul,
+	.mw-content-rtl .mw-content-ltr .toc ul {
+		text-align: left;
+	}
+	
+	/* @noflip */ .mw-content-rtl .toc ul,
+	.mw-content-ltr .mw-content-rtl .toc ul {
+		text-align: right;
+	}
+	
+	/* @noflip */ .mw-content-ltr .toc ul ul,
+	.mw-content-rtl .mw-content-ltr .toc ul ul {
+		margin: 0 0 0 2em;
+	}
+	
+	/* @noflip */ .mw-content-rtl .toc ul ul,
+	.mw-content-ltr .mw-content-rtl .toc ul ul {
+		margin: 0 2em 0 0;
+	}
+	
+	.toc .toctitle {
+		direction: ltr;
+	}
+	
+	#mw-clearyourcache,
+	#mw-sitecsspreview,
+	#mw-sitejspreview,
+	#mw-usercsspreview,
+	#mw-userjspreview {
+		direction: ltr;
+		unicode-bidi: embed;
+	}
+	
+	#mw-revision-info,
+	#mw-revision-info-current,
+	#mw-revision-nav {
+		direction: ltr;
+	}
+	
+	/* Images */
+	
+	/* @noflip */ div.tright,
+	div.floatright,
+	table.floatright {
+		clear: right;
+		float: right;
+	}
+	
+	/* @noflip */ div.tleft,
+	div.floatleft,
+	table.floatleft {
+		float: left;
+		clear: left;
+	}
+	
+	div.floatright,
+	table.floatright,
+	div.floatleft,
+	table.floatleft {
+		position: relative;
+	}
+	
+	/* T14205 */
+	#mw-credits a {
+		unicode-bidi: embed;
+	}
+	
+	/* Accessibility */
+	.mw-jump,
+	#jump-to-nav {
+		overflow: hidden;
+		height: 0;
+		zoom: 1; /* http://webaim.org/techniques/skipnav/#iequirk */
+	}
+	
+	/* Print footer should be hidden by default in screen. */
+	.printfooter {
+		display: none;
+	}
+	
+	/* For developers */
+	.xdebug-error {
+		position: absolute;
+		z-index: 99;
+	}
+	
+	.mw-editsection,
+	#jump-to-nav {
+		-moz-user-select: none;
+		-webkit-user-select: none;
+		-ms-user-select: none;
+		user-select: none;
+	}
+	
+	/* Display editsection links smaller and next to headings */
+	.mw-editsection,
+	.mw-editsection-like {
+		font-size: small;
+		font-weight: normal;
+		margin-left: 1em;
+		vertical-align: baseline;
+		/* Reset line-height; headings tend to have it set to larger values */
+		line-height: 1em;
+	}
+	
+	/* Correct directionality when page dir is different from site/user dir */
+	/* @noflip */
+	.mw-content-ltr .mw-editsection,
+	.mw-content-rtl .mw-content-ltr .mw-editsection {
+		margin-left: 1em;
+	}
+	
+	/* @noflip */
+	.mw-content-rtl .mw-editsection,
+	.mw-content-ltr .mw-content-rtl .mw-editsection {
+		margin-right: 1em;
+	}
+	
+	/* Prevent citations and subscripts from interfering with the line-height */
+	sup,
+	sub {
+		line-height: 1;
+	}}

--- a/skin.json
+++ b/skin.json
@@ -1,6 +1,6 @@
 {
 	"name": "Pivot",
-	"version": "2.2.2-dev",
+	"version": "2.3.0-dev",
 	"author": [
 		"Tom Hutchison",
 		"..."
@@ -13,7 +13,7 @@
 		"pivot": "Pivot"
 	},
 	"requires": {
-		"MediaWiki": ">= 1.31.0"
+		"MediaWiki": ">= 1.35.0"
 	},
 	"MessagesDirs": {
 		"Skinpivot": [
@@ -29,6 +29,7 @@
 			"styles": [
 				"assets/stylesheets/normalize.css",
 				"assets/stylesheets/font-awesome.css",
+				"assets/stylesheets/legacy.css",
 				"assets/stylesheets/foundation.css",
 				"assets/stylesheets/pivot.css",
 				"assets/stylesheets/fontawsome.css",

--- a/skin.json
+++ b/skin.json
@@ -1,6 +1,6 @@
 {
 	"name": "Pivot",
-	"version": "2.3.0-dev",
+	"version": "2.3.0",
 	"author": [
 		"Tom Hutchison",
 		"..."


### PR DESCRIPTION

This is a release for compatibility with MW >= 1.35. 

## Version 2.3.0
* [compatibility, CSS] Load MW core CSS that was dropped in MW 1.35
* [code] Drop Travis-CI and move to CircleCI
* [code] Update php-parallel-lint to a supported branch with PHP 8.0
* [deprecated, code] Updated deprecated code

Also, it includes all changes since v2.2.0. v2.2.2 was released as the last compatible release with MW >= 1.31 and MW <= 1.34

Just for reference, here are the changes since v2.2.0

## Version 2.2.2
* [bug, enhancement] Fix to allow multiple methods of login such as MW-OAuth2Client - Issue #99
* [bug, enhancement] Left-menu search (on mobile widths only) doesn't auto-complete #98

## Version 2.2.1
* [enhancement] Enumeration and Listings #54
* [bug] Search results page - limited width #58
* [bug] Syntax error in pivot.css Issue #89 
* [bug] Personal tools menu name not translated into other languages Issue #88
* [bug] Search autocomplete not available on small screens Issue #85
* [bug] The links in the menu titles on the left seem to be clickable off they should not be. Issue #68 
