### PR TITLE
1.39

### DIFF
--- a/Pivot.skin.php
+++ b/Pivot.skin.php
@@ -106,7 +106,7 @@ class pivotTemplate extends BaseTemplate {
 					</section>
 					
 					<section id="right-nav-aside" class="right-small">
-					<a href="#" class="right-off-canvas-toggle"><span id="menu-user"><i class="fa <?php if ($wgUser->isLoggedIn()): ?>fa-user<?php else: ?>fa-navicon<?php endif; ?> fa-lg"></i></span></a>
+					<a href="#" class="right-off-canvas-toggle"><span id="menu-user"><i class="fa <?php if ($wgUser->isRegistered()): ?>fa-user<?php else: ?>fa-navicon<?php endif; ?> fa-lg"></i></span></a>
 					</section>
 				</nav>
 				<?php if ($wgPivotFeatures['fixedNavBar'] != false) echo "</div>"; ?>
@@ -129,7 +129,7 @@ class pivotTemplate extends BaseTemplate {
 					
 					<aside class="right-off-canvas-menu">
 					  <ul class="off-canvas-list">
-					<?php if ($wgUser->isLoggedIn()): ?>
+					<?php if ($wgUser->isRegistered()): ?>
 						<li id="personal-tools"><label><?php echo wfMessage( 'pivot-personal-tools' )->text() ?></label></li>
 						<?php foreach ($this->getPersonalTools() as $key => $item) { echo $this->makeListItem($key, $item); } ?>
 							<?php else: ?>
@@ -173,7 +173,7 @@ class pivotTemplate extends BaseTemplate {
 												<!-- Output page indicators -->
 												<?php echo $this->getIndicators(); ?>
 												<!-- If user is logged in output echo location -->
-												<?php if ($wgUser->isLoggedIn()): ?>
+												<?php if ($wgUser->isRegistered()): ?>
 												<div id="echo-notifications">
 												<div id="echo-notifications-alerts"></div>
 												<div id="echo-notifications-messages"></div>
@@ -189,7 +189,7 @@ class pivotTemplate extends BaseTemplate {
 										</div>
 									</div>
 								
-									<?php if ($wgUser->isLoggedIn() || $wgPivotFeatures['showActionsForAnon']): ?>
+									<?php if ($wgUser->isRegistered() || $wgPivotFeatures['showActionsForAnon']): ?>
 										<a href="#" data-options="align:left" data-dropdown="drop1" class="button secondary small radius pull-right hide-for-print" id="drop"><i class="fa fa-navicon fa-lg"><span id="page-actions" class="show-for-medium-up">&nbsp;<?php echo wfMessage( 'actions' )->text() ?></span></i></a>
 										<ul id="drop1" class="tiny content f-dropdown" data-dropdown-content>
 											<?php foreach($this->data['content_actions'] as $key => $tab) { echo preg_replace(array('/\sprimary="1"/', '/\scontext="[a-z]+"/', '/\srel="archives"/'),'',$this->makeListItem($key, $tab)); } ?>

--- a/Pivot.skin.php
+++ b/Pivot.skin.php
@@ -9,8 +9,6 @@
  
 
 class SkinPivot extends SkinTemplate {
-	public $skinname = 'pivot', $stylename = 'pivot', $template = 'pivotTemplate', $useHeadElement = true;
-	
 	public function getDefaultModules() {
 		global $wgPivotFeatures;
 		$wgPivotFeaturesDefaults = array(
@@ -37,29 +35,16 @@ class SkinPivot extends SkinTemplate {
 		if ( $wgPivotFeatures['preloadFontAwesome'] ) {
 			$this->getOutput()->addHeadItem('font', '<link rel="preload" href="'.$wgLocalStylePath.'/pivot/assets/fonts/fontawesome-webfont.woff2?v=4.7.0" as="font" type="font/woff2" crossorigin="anonymous" />');
 		}
-		
-		$this->getOutput()->addModuleStyles('skins.pivot.styles');
-    	return parent::getDefaultModules();
+		return parent::getDefaultModules();
 	}
-	
-	public function initPage(OutputPage $out) {
-		global $wgLocalStylePath;
-		parent::initPage($out);
-
-		$viewport_meta = 'width=device-width, user-scalable=yes, initial-scale=1.0';
-		$out->addMeta('viewport', $viewport_meta);
-		$out->addModules('skins.pivot.js');
-	}
-
 }
 
 
-class pivotTemplate extends BaseTemplate {
+class PivotTemplate extends BaseTemplate {
 	public function execute() {
 		global $wgUser;
 		global $wgPivotFeatures;
 		Wikimedia\suppressWarnings();
-		$this->html('headelement');
 		switch ($wgPivotFeatures['usePivotTabs']) {
 			case true:
 			    ob_start();
@@ -277,15 +262,10 @@ class pivotTemplate extends BaseTemplate {
 		<div>
 			<a class="exit-off-canvas"></a>	
 		</div>
-		
-		
-		<?php $this->printTrail(); ?>
 
 			<?php if ($this->data['isarticle'] && $wgPivotFeatures['addThisPUBID'] !== '') { ?>
 				<script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid=<?php echo $wgPivotFeatures['addThisPUBID']; ?>" async="async"></script>
 			<?php } ?>	
-		</body>
-		</html>
 
 <?php
 		Wikimedia\restoreWarnings();

--- a/skin.json
+++ b/skin.json
@@ -10,10 +10,26 @@
 	"descriptionmsg": "pivot-desc",
 	"type": "skin",
 	"ValidSkinNames": {
-		"pivot": "Pivot"
+		"pivot": {
+			"class": "SkinPivot",
+			"args": [
+				{
+					"name": "pivot",
+					"template": "PivotTemplate",
+					"bodyOnly": true,
+					"responsive": true,
+					"scripts": [
+						"skins.pivot.js"
+					],
+					"styles": [
+						"skins.pivot.styles"
+					]
+				}
+			]
+		}
 	},
 	"requires": {
-		"MediaWiki": ">= 1.35.0"
+		"MediaWiki": ">= 1.39.0"
 	},
 	"MessagesDirs": {
 		"Skinpivot": [


### PR DESCRIPTION
This fixes warnings in 1.39. There is no urgency with this one. #115 is more urgent given the skin is using incompatible code.

### PR Submission:

* [ ] Have tested this PR and it adds a feature or fixes an issue noted below.

### Additional Information Below

* If you remove the line `Wikimedia\suppressWarnings();` you'll see various warnings about future breakages. This changes takes care of all of these.

No urgency to merge this one. Those warnings won't likely become a problem until at least MediaWiki 1.41.
